### PR TITLE
Quitada version 2.7 de python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"


### PR DESCRIPTION
Debido a que generaba errores en las builds de Travis